### PR TITLE
Refactoring/open channel

### DIFF
--- a/lib/src/absinthe_socket_link.dart
+++ b/lib/src/absinthe_socket_link.dart
@@ -18,7 +18,7 @@ class AbsintheSocketLink extends Link {
         _serializer = serializer,
         _parser = parser;
 
-  void openChannel() {
+  void _connect() {
     if (_channel == null) {
       _channel = _socket.addChannel(topic: _absintheChannelName);
       _channel!.join();
@@ -29,7 +29,7 @@ class AbsintheSocketLink extends Link {
   @override
   Stream<Response> request(Request request, [NextLink? forward]) {
     assert(forward == null, '$this does not support a NextLink (got $forward)');
-    openChannel();
+    _connect();
 
     StreamSubscription? closeSocketSubscription;
     StreamSubscription? openSocketSubscription;


### PR DESCRIPTION
Refatorando a função openChannel:
1 - deixando ela privada.
2 - mudando sua nomenclatura.